### PR TITLE
ci: add Codecov patch coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Run unit tests with coverage
         run: npm run test:cov
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-report
-          path: coverage/
-          retention-days: 7
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true
 
   build:
     name: Build

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project: off
+    patch:
+      default:
+        target: 90%
+        threshold: 1%
+
+comment:
+  layout: "diff, files"
+  require_changes: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,14 +15,6 @@ module.exports = {
     '!src/infrastructure/logging/**',
   ],
   coverageDirectory: './coverage',
-  coverageThreshold: {
-    global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-  },
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@domain/(.*)$': '<rootDir>/src/domain/$1',


### PR DESCRIPTION
## Summary
- Remove global 80% coverage threshold from jest config (Codecov handles patch coverage now)
- Replace artifact upload with Codecov integration in CI workflow
- Add `codecov.yml` with 90% patch coverage target, project coverage off

## Test plan
- [ ] CI passes (lint, test, build)
- [ ] Codecov uploads coverage successfully
- [ ] `codecov/patch` status check appears on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)