### PR TITLE
ci: set fail_ci_if_error to false for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   build:
     name: Build


### PR DESCRIPTION
Align with other repos — Codecov enforcement is via codecov/patch status check, not CI step failure.